### PR TITLE
RAVE-1269 | Errors in opensocial gadget rendering should callback with a...

### DIFF
--- a/rave-portal-resources/src/main/webapp/static/script/core/rave_opensocial.js
+++ b/rave-portal-resources/src/main/webapp/static/script/core/rave_opensocial.js
@@ -218,6 +218,7 @@ define(['underscore', 'core/rave_view_manager', 'core/rave_api', 'core/rave_open
         exports.renderWidget = function (widget, el, opts) {
             if (widget.error) {
                 widget.renderError(el, widget.error.message);
+                opts && opts.callback && opts.callback({'error' : widget.error});
                 return;
             }
             opts = opts || {};


### PR DESCRIPTION
...n error
